### PR TITLE
Changed sqlite C api int functions to allow bigger Integer values

### DIFF
--- a/lib/motion-sqlite3/result_set.rb
+++ b/lib/motion-sqlite3/result_set.rb
@@ -31,7 +31,7 @@ module SQLite3
         when SQLITE_BLOB
           row[name] = NSData.dataWithBytes(sqlite3_column_blob(@handle.value, i), length: sqlite3_column_bytes(@handle.value, i))
         when SQLITE_INTEGER
-          row[name] = sqlite3_column_int(@handle.value, i)
+          row[name] = sqlite3_column_int64(@handle.value, i)
         when SQLITE_FLOAT
           row[name] = sqlite3_column_double(@handle.value, i)
         end

--- a/lib/motion-sqlite3/statement.rb
+++ b/lib/motion-sqlite3/statement.rb
@@ -53,7 +53,7 @@ module SQLite3
       when String, Symbol
         result = sqlite3_bind_text(@handle.value, index, value, -1, lambda { |arg| })
       when Integer
-        result = sqlite3_bind_int(@handle.value, index, value)
+        result = sqlite3_bind_int64(@handle.value, index, value)
       when Float
         result = sqlite3_bind_double(@handle.value, index, value)
       when NSData


### PR DESCRIPTION
Eleven digit integers where being truncated before this change.