### PR TITLE
Important updates and version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,23 @@
 language: objective-c
+osx_image: xcode11.3
+env:
+  global:
+    - RUBYMOTION_LICENSE=1dcac45cc434293009f74b33037bdf7361a3a1ff # Official license key for open-source projects
+    - TMP_DIR=./tmp # For motion repo, so it doesn't attempt to use /tmp, to which it has no access
+    - OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 before_install:
-    - sudo chown -R travis ~/Library/RubyMotion
-    - mkdir -p ~/Library/RubyMotion/build
-
+  - brew update
+  - brew outdated xctool || brew upgrade xctool
+  - (xcrun simctl list)
+  - wget http://travisci.rubymotion.com/ -O RubyMotion-TravisCI.pkg
+  - sudo installer -pkg RubyMotion-TravisCI.pkg -target /
+  - cp -r /usr/lib/swift/*.dylib /Applications/Xcode.app/Contents/Frameworks/
+  - touch /Applications/Xcode.app/Contents/Frameworks/.swift-5-staged
+  - sudo mkdir -p ~/Library/RubyMotion/build
+  - sudo chown -R travis ~/Library/RubyMotion
+  - eval "sudo motion activate $RUBYMOTION_LICENSE"
+  - sudo motion update
+  - (motion --version)
+  - (ruby --version)
+  - motion repo
 script: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -52,7 +52,3 @@ Usage
 * Use `execute` to run SQL statements. All SQL statements are first prepared, and parameters can be passed as an Array or a Hash. If a Hash is passed, then the SQLite named parameter syntax is assumed to be in use.
 * Use `execute_debug` to see the SQL statement and paramaters passed in the REPL. You should not use this method in production.
 * Use `execute_scalar` to run SQL statements and return the first column of the first row. This is useful for queries like `SELECT COUNT(*) FROM posts`.
-
-Status
-----------
-Still in early stages. I'm hacking on it.

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios'
 
 require "bundler/gem_tasks"
@@ -9,13 +10,7 @@ Bundler.require :default
 Motion::Project::App.setup do |app|
   app.name = 'motion-sqlite3'
 
-  base_dir = File.dirname(__FILE__)
-  app.files += Dir.glob(File.join(base_dir, "lib/motion-sqlite3/**/*.rb"))
-
   if ENV["DEFAULT_PROVISIONING_PROFILE"]
     app.provisioning_profile = ENV["DEFAULT_PROVISIONING_PROFILE"]
   end
-
-  app.libs << "/usr/lib/libsqlite3.dylib"
-  app.include 'sqlite3.h'
 end

--- a/lib/motion-sqlite3/version.rb
+++ b/lib/motion-sqlite3/version.rb
@@ -1,3 +1,3 @@
 module SQLite3
-  VERSION = "0.5.3"
+  VERSION = "1.0.0"
 end

--- a/motion-sqlite3.gemspec
+++ b/motion-sqlite3.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.version       = SQLite3::VERSION
 
   gem.add_development_dependency 'rake'
-  gem.add_dependency 'motion.h', '~> 0.0.4'
+  gem.add_dependency 'motion.h', '~> 0.0.6'
 end


### PR DESCRIPTION
This PR brings this repo in line with the latest RubyMotion open-source project template (fixing broken test suite), and requiring the latest version of `motion.h`.

By the way @mattgreen, if you're interested, we can migrate this repo over to http://github.com/rubymotion-community where we have other popular RubyMotion gems maintained by the community. But if you'd like to remain sole admin on this repo, that's fine too.